### PR TITLE
Support for netstandard2.0 in library and net48 in sample app

### DIFF
--- a/Musement.Extensions.Configuration.ConfigCat/ConfigCatConfigurationProvider.cs
+++ b/Musement.Extensions.Configuration.ConfigCat/ConfigCatConfigurationProvider.cs
@@ -40,9 +40,10 @@ namespace Musement.Extensions.Configuration.ConfigCat
             _client.ConfigChanged += (s, e) => Reload();
 
             _keyFilter = options.KeyFilter ?? (_ => true);
+#pragma warning disable CA1307 // Specify StringComparison for clarity - REASON: support for netstandard2.0
             _keyMapper = options.KeyMapper ??
-                         ((key, value) => key.Replace("__", ConfigurationPath.KeyDelimiter,
-                             StringComparison.InvariantCultureIgnoreCase));
+                         ((key, value) => key.Replace("__", ConfigurationPath.KeyDelimiter));
+#pragma warning restore CA1307 // Specify StringComparison for clarity
         }
 
         private void Reload()

--- a/Musement.Extensions.Configuration.ConfigCat/Musement.Extensions.Configuration.ConfigCat.csproj
+++ b/Musement.Extensions.Configuration.ConfigCat/Musement.Extensions.Configuration.ConfigCat.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/SampleApp/Program.cs
+++ b/SampleApp/Program.cs
@@ -27,7 +27,9 @@ namespace SampleApp
                         };
                         o.KeyMapper = (key, value) =>
                         {
-                            var mappedKey = key.Replace("__", ConfigurationPath.KeyDelimiter, StringComparison.OrdinalIgnoreCase);
+#pragma warning disable CA1307 // Specify StringComparison for clarity REASON: support net48
+                            var mappedKey = key.Replace("__", ConfigurationPath.KeyDelimiter);
+#pragma warning restore CA1307 // Specify StringComparison for clarity
                             return "Cat:" + mappedKey;
                         };
                     });
@@ -38,9 +40,9 @@ namespace SampleApp
 
             do
             {
-                foreach (var (key, value) in config.GetSection("Cat").AsEnumerable())
+                foreach (var configSection in config.GetSection("Cat").AsEnumerable())
                 {
-                    Console.WriteLine($"{key}: {value}");
+                    Console.WriteLine($"{configSection.Key}: {configSection.Value}");
                 }
 
                 await Task.Delay(15_000);

--- a/SampleApp/Program.cs
+++ b/SampleApp/Program.cs
@@ -1,10 +1,9 @@
+using ConfigCat.Client;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using System;
 using System.Threading.Tasks;
-using ConfigCat.Client;
-using ConfigCat.Client.Configuration;
 
 namespace SampleApp
 {

--- a/SampleApp/SampleApp.csproj
+++ b/SampleApp/SampleApp.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net48</TargetFrameworks>
     <UserSecretsId>5dd35087-141f-49c7-bdde-c9c8e8747bd5</UserSecretsId>
   </PropertyGroup>
 


### PR DESCRIPTION
With a minor change this can be built to support netstandard2.0 and therefore a larger range of older projects, including net48.
Multi-targeted the library for net6.0 and netstandard2.0
Multi-targeted the sample app for net6.0 and net48
Added suppressions in code for clarity of changes to support netstandard2.0.